### PR TITLE
backup-operator: close s3 reader after saving snapshot

### DIFF
--- a/pkg/backup/writer/s3_writer.go
+++ b/pkg/backup/writer/s3_writer.go
@@ -59,6 +59,9 @@ func (s3w *s3Writer) Write(ctx context.Context, path string, r io.Reader) (int64
 	if err != nil {
 		return 0, err
 	}
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if resp.ContentLength == nil {
 		return 0, fmt.Errorf("failed to compute s3 object size")
 	}


### PR DESCRIPTION
Backport of the following fix in etcd-operator:

https://github.com/coreos/etcd-operator/pull/1976/commits/eb6e6d5582460cb16f00bf3a44ea761bb88fb75b